### PR TITLE
Use input override global position if set to calculate diff.

### DIFF
--- a/demo/addons/ropesim/RopeInteraction.gd
+++ b/demo/addons/ropesim/RopeInteraction.gd
@@ -84,7 +84,7 @@ func _on_after_update() -> void:
         on_movement_request.emit(target_node, _anchor)
         return
 
-    var diff := _anchor.global_position - target_node.global_position
+    var diff := _anchor.global_position - (input_node_override if input_node_override else target_node).global_position
 
     if diff.length_squared() < 0.01 * 0.01:
         return


### PR DESCRIPTION
Ive made a change to use the input override position to calculate the rope interaction diff if it is set. 
As far as I can tell this is a bug? 

When the override position is set without this change the `CharacterBody2D` on that side of the `RopeInteraction` will be pushed towards the input override position point continuously.

I could also have been using it incorrectly.

